### PR TITLE
Enable pretty URLs

### DIFF
--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -15,7 +15,7 @@ class Admin::ArticlesController < ApplicationController
   end
 
   def destroy
-    @article = Article.find_by_slug_or_id(params[:id])
+    @article = Article.find(params[:id].to_i)
     if @article.destroy
       redirect_to admin_articles_path
       # TODO: Notify user that deleted successfully
@@ -30,11 +30,11 @@ class Admin::ArticlesController < ApplicationController
   end
 
   def edit
-    @article = Article.find_by_slug_or_id(params[:id])
+    @article = Article.find(params[:id].to_i)
   end
 
   def update
-    @article = Article.find_by_slug_or_id(params[:id])
+    @article = Article.find(params[:id].to_i)
     if @article.update(permitted_params)
       redirect_to admin_articles_path
     else

--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -15,7 +15,7 @@ class Admin::ArticlesController < ApplicationController
   end
 
   def destroy
-    @article = Article.find(params[:id])
+    @article = Article.find_by_slug_or_id(params[:id])
     if @article.destroy
       redirect_to admin_articles_path
       # TODO: Notify user that deleted successfully
@@ -30,11 +30,11 @@ class Admin::ArticlesController < ApplicationController
   end
 
   def edit
-    @article = Article.find(params[:id])
+    @article = Article.find_by_slug_or_id(params[:id])
   end
 
   def update
-    @article = Article.find(params[:id])
+    @article = Article.find_by_slug_or_id(params[:id])
     if @article.update(permitted_params)
       redirect_to admin_articles_path
     else

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -4,6 +4,10 @@ class ArticlesController < ApplicationController
   end
 
   def show
-    @article = Article.find(params[:id])
+    if params[:id].to_i > 0
+      @article = Article.find(params[:id])
+    else
+      @article = Article.where(slug: params[:id]).first
+    end
   end
 end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -4,6 +4,10 @@ class ArticlesController < ApplicationController
   end
 
   def show
-    @article = Article.find_by_slug_or_id(params[:id])
+    @article = Article.find(params[:id].to_i)
+    # To handle "old" slugs after a title has changed, redirect any URL requested which contains a "-" to the latest canonical URL
+    if params[:id].include?("-") && !article_path(@article).include?(params[:id])
+      redirect_to article_path(@article)
+    end
   end
 end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -4,10 +4,6 @@ class ArticlesController < ApplicationController
   end
 
   def show
-    if params[:id].to_i > 0
-      @article = Article.find(params[:id])
-    else
-      @article = Article.where(slug: params[:id]).first
-    end
+    @article = Article.find_by_slug_or_id(params[:id])
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -6,7 +6,7 @@ class Article < ApplicationRecord
   before_save :set_slug
 
   def to_param
-    self.slug
+    self.slug || self.id
   end
 
   def set_slug

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -19,4 +19,16 @@ class Article < ApplicationRecord
     end
     self.slug = current_slug
   end
+
+  class << self
+    # Where "arg" could be either a string slug or an integer ID
+    def find_by_slug_or_id(arg)
+      if arg.to_i > 0
+        @article = Article.find(arg)
+      else
+        @article = Article.where(slug: arg).first
+      end
+    end
+
+  end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,34 +1,15 @@
 class Article < ApplicationRecord
   validates :title, presence: true
   validates :body, presence: true
-  validates :slug, uniqueness: true
 
-  before_save :set_slug
+  before_save :set_slug, :if => Proc.new{ self.title_changed? }
 
   def to_param
-    self.slug || self.id
+    "#{self.id}-#{self.slug}"
   end
 
   def set_slug
-    base_slug = self.title.parameterize(separator: "_")
-    counter = 1
-    current_slug = base_slug
-    while self.class.find_by(slug: current_slug)
-      current_slug = "#{base_slug}_#{counter.to_s}"
-      counter += 1
-    end
-    self.slug = current_slug
+    self.slug = self.title.parameterize(separator: "-")
   end
 
-  class << self
-    # Where "arg" could be either a string slug or an integer ID
-    def find_by_slug_or_id(arg)
-      if arg.to_i > 0
-        @article = Article.find(arg)
-      else
-        @article = Article.where(slug: arg).first
-      end
-    end
-
-  end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,4 +1,22 @@
 class Article < ApplicationRecord
   validates :title, presence: true
   validates :body, presence: true
+  validates :slug, uniqueness: true
+
+  before_save :set_slug
+
+  def to_param
+    self.slug
+  end
+
+  def set_slug
+    base_slug = self.title.parameterize(separator: "_")
+    counter = 1
+    current_slug = base_slug
+    while self.class.find_by(slug: current_slug)
+      current_slug = "#{base_slug}_#{counter.to_s}"
+      counter += 1
+    end
+    self.slug = current_slug
+  end
 end

--- a/db/migrate/20220430221336_add_slug_to_articles.rb
+++ b/db/migrate/20220430221336_add_slug_to_articles.rb
@@ -1,0 +1,9 @@
+class AddSlugToArticles < ActiveRecord::Migration[7.0]
+  def up
+    add_column :articles, :slug, :string
+  end
+
+  def down
+    remove_column :articles, :slug
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_30_030359) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_30_221336) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_30_030359) do
     t.text "body"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "slug"
   end
 
   create_table "people", force: :cascade do |t|

--- a/scripts/20220430_add_slugs_to_existing_articles.rb
+++ b/scripts/20220430_add_slugs_to_existing_articles.rb
@@ -1,0 +1,1 @@
+Article.all.each{|a| a.set_slug && a.save }

--- a/spec/controllers/admin/admin_article_spec.rb
+++ b/spec/controllers/admin/admin_article_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Admin Articles controller", type: :request do
     end
 
     it "renders the edit template if slug is passed instead of ID" do
-      get "/admin/articles/#{a.slug}/edit"
+      get "/admin/articles/#{a.id}-#{a.slug}/edit"
       expect(response).to render_template("edit")
       expect(response.status).to eq(200)
     end
@@ -72,7 +72,7 @@ RSpec.describe "Admin Articles controller", type: :request do
     end
 
     it "should update the article if everything's filled out, and slug is passed" do
-      put "/admin/articles/#{a.slug}", params: {id: a.id, article: {title: "You Didn't Expect This, Did You?", body: "My Body"}}
+      put "/admin/articles/#{a.id}-#{a.slug}", params: {id: a.id, article: {title: "You Didn't Expect This, Did You?", body: "My Body"}}
       expect(response).to redirect_to(admin_articles_path)
       expect(Article.find(a.id).title).to eq("You Didn't Expect This, Did You?")
     end
@@ -85,7 +85,7 @@ RSpec.describe "Admin Articles controller", type: :request do
     end
 
     it "should be able to destroy by slug" do
-      delete "/admin/articles/#{a.slug}"
+      delete "/admin/articles/#{a.id}-#{a.slug}"
       expect{ Article.find(a.id) }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end

--- a/spec/controllers/admin/admin_article_spec.rb
+++ b/spec/controllers/admin/admin_article_spec.rb
@@ -46,6 +46,12 @@ RSpec.describe "Admin Articles controller", type: :request do
       expect(response).to render_template("edit")
       expect(response.status).to eq(200)
     end
+
+    it "renders the edit template if slug is passed instead of ID" do
+      get "/admin/articles/#{a.slug}/edit"
+      expect(response).to render_template("edit")
+      expect(response.status).to eq(200)
+    end
   end
 
   describe "update" do
@@ -64,11 +70,22 @@ RSpec.describe "Admin Articles controller", type: :request do
       expect(response).to redirect_to(admin_articles_path)
       expect(Article.find(a.id).title).to eq("You Didn't Expect This, Did You?")
     end
+
+    it "should update the article if everything's filled out, and slug is passed" do
+      put "/admin/articles/#{a.slug}", params: {id: a.id, article: {title: "You Didn't Expect This, Did You?", body: "My Body"}}
+      expect(response).to redirect_to(admin_articles_path)
+      expect(Article.find(a.id).title).to eq("You Didn't Expect This, Did You?")
+    end
   end
 
   describe "destroy" do
     it "should destroy an article" do
       delete "/admin/articles/#{a.id}", params: {id: a.id}
+      expect{ Article.find(a.id) }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "should be able to destroy by slug" do
+      delete "/admin/articles/#{a.slug}"
       expect{ Article.find(a.id) }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end

--- a/spec/controllers/article_spec.rb
+++ b/spec/controllers/article_spec.rb
@@ -20,18 +20,33 @@ RSpec.describe "Articles Controller", :type => :request do
     end
 
     it "renders the show template" do
-      get "/articles/#{@a.id}"
+      get "/articles/#{@a.id}-#{@a.slug}"
       expect(response).to render_template("show")
     end
 
     it "produces an OK status code" do
-      get "/articles/#{@a.id}"
+      get "/articles/#{@a.id}-#{@a.slug}"
       expect(response.status).to eq(200)
     end
 
     it "can access an article by title" do
-      get "/articles/sample_title"
+      get "/articles/#{@a.id}-sample-title"
       expect(response).to render_template("show")
+    end
+
+    it "URL changes after the title changes" do
+      @a.title = "New Title"
+      @a.save
+      get "/articles/#{@a.id}-new-title"
+      expect(response).to render_template("show")
+    end
+
+    it "the old URL still works, but redirects to the new URL" do
+      @a.title = "New Title"
+      @a.save
+      get "/articles/#{@a.id}-sample-title"
+      expect(response.status).to eq(302)
+      expect(response).to redirect_to("/articles/#{@a.id}-new-title")
     end
   end
 

--- a/spec/controllers/article_spec.rb
+++ b/spec/controllers/article_spec.rb
@@ -1,32 +1,38 @@
 require 'rails_helper'
 
-RSpec.describe ArticlesController do
+RSpec.describe "Articles Controller", :type => :request do
 
   describe "GET index" do
     it "renders the index template" do
-      get :index
+      get "/"
       expect(response).to render_template("index")
     end
 
     it "produces an OK status code" do
-      get :index
+      get "/"
       expect(response.status).to eq(200)
     end
   end
 
   describe "GET show" do
-    let(:a) {
-      FactoryBot.create(:article)
-    }
+    before(:each) do
+      @a = FactoryBot.create(:article, title: "Sample Title")
+    end
 
     it "renders the show template" do
-      get :show, params: {id: a.id}
+      get "/articles/#{@a.id}"
       expect(response).to render_template("show")
     end
 
     it "produces an OK status code" do
-      get :show, params: {id: a.id}
+      get "/articles/#{@a.id}"
       expect(response.status).to eq(200)
     end
+
+    it "can access an article by title" do
+      get "/articles/sample_title"
+      expect(response).to render_template("show")
+    end
   end
+
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -21,4 +21,14 @@ RSpec.describe Article, type: :model do
     expect(c.save).to be(true)
     expect(Article.count).to eq(1)
   end
+
+  it "should save a slug equal to the title parameterized" do
+    c.save
+    expect(c.slug).to eq("this_is_a_title")
+  end
+
+  it "should set the default URL for an article to its pretty URL (slug)" do
+    c.save
+    expect(article_path(c)).to eq("/articles/this_is_a_title")
+  end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -24,11 +24,11 @@ RSpec.describe Article, type: :model do
 
   it "should save a slug equal to the title parameterized" do
     c.save
-    expect(c.slug).to eq("this_is_a_title")
+    expect(c.slug).to eq("this-is-a-title")
   end
 
   it "should set the default URL for an article to its pretty URL (slug)" do
     c.save
-    expect(article_path(c)).to eq("/articles/this_is_a_title")
+    expect(article_path(c)).to eq("/articles/#{c.id}-this-is-a-title")
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,6 +39,7 @@ RSpec.configure do |config|
   # examples within a transaction, remove the following line or assign false
   # instead of true.
   config.use_transactional_fixtures = true
+  config.include Rails.application.routes.url_helpers
 
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false


### PR DESCRIPTION
1. Pages may now be accessed either by ID or slug (a parameterized title). E.g. an article with ID 2 and title "This Title" can be accessed at "/article/2" or "/article/this_title"
2. The URL helpers now default to the slug, for better SEO
3. Slugs are set as soon as articles are saved, with care being taken to ensure no duplicate slug can be added
4. Includes a script to set slugs for existing articles. This must be run manually after the deploy.